### PR TITLE
make isolate work on submodule objects

### DIFF
--- a/dingus.py
+++ b/dingus.py
@@ -98,7 +98,7 @@ class _Patcher:
 
 def isolate(object_path):
     def decorator(fn):
-        module_name, object_name = object_path.split('.')
+        module_name, object_name = object_path.rsplit('.', 1)
         module = sys.modules[module_name]
         neighbors = set(dir(module)) - set([object_name])
         for neighbor in neighbors:

--- a/tests/test_isolation.py
+++ b/tests/test_isolation.py
@@ -44,3 +44,13 @@ class WhenIsolating:
         assert not isinstance(os.walk, Dingus)
 
 
+class WhenIsolatingSubmoduleObjects:
+    def should_isolate(self):
+        @isolate("os.path.isdir")
+        def ensure_isolation():
+            assert not isinstance(os.path.isdir, Dingus)
+            assert isinstance(os.path.isfile, Dingus)
+
+        assert not isinstance(os.path.isfile, Dingus)
+        ensure_isolation()
+        assert not isinstance(os.path.isfile, Dingus)


### PR DESCRIPTION
Refs #12. I have not tried this on real code yet. Trying something similar to this on a complicated module broke `False` in an isolated instance method, but I was hurried that day and may have simply mistyped something.
