### PR TITLE
Extract TestCase to enable override for use by other test runners

### DIFF
--- a/dingus.py
+++ b/dingus.py
@@ -140,7 +140,7 @@ class Call(tuple):
         self.args = self[1]
         self.kwargs = self[2]
         self.return_value = self[3]
-        
+
     def __getnewargs__(self):
         return (self.name, self.args, self.kwargs, self.return_value)
 
@@ -272,12 +272,12 @@ class Dingus(object):
 
     def _should_ignore_attribute(self, name):
         return name in ['__pyobjc_object__', '__getnewargs__']
-    
+
     def __getstate__(self):
         # Python cannot pickle a instancemethod
         # http://bugs.python.org/issue558238
         return [ (attr, value) for attr, value in self.__dict__.items() if attr != "__init__"]
-    
+
     def __setstate__(self, state):
         self.__dict__.update(state)
         self._replace_init_method()

--- a/tests/test_dingus_test_case.py
+++ b/tests/test_dingus_test_case.py
@@ -4,6 +4,7 @@ from tests import test_case_fixture as module
 from tests.test_case_fixture import ClassUnderTest, Collaborator
 
 from dingus import DingusTestCase, Dingus
+import dingus
 
 
 class WhenObjectIsExcludedFromTest:
@@ -66,3 +67,27 @@ class WhenCallingTeardownFunction:
     def should_leave_globals_as_they_were_before_dingusing(self):
         assert module.__dict__ == self.original_module_dict
 
+
+class WhenCustomTestCaseBase:
+    def setup(self):
+        class CustomTestBase(dingus.TestCase):
+            """
+            This TestBase enables setup/teardown in py.test tests
+            """
+            def setup_method(self, method):
+                self.setup()
+
+            def teardown_method(self, method):
+                self.teardown()
+
+        class TestCase(DingusTestCase(module.ClassUnderTest,
+                base=CustomTestBase)):
+            pass
+        self.test_case_instance = TestCase()
+        self.test_case_instance.setup()
+
+    def teardown(self):
+        self.test_case_instance.teardown()
+
+    def test_case_should_have_setup_method_method(self):
+        assert hasattr(self.test_case_instance, 'setup_method')


### PR DESCRIPTION
We use Dingus with pytest, which doesn't recognize the setup/teardown methods in TestCase, so we have a convoluted way to customize the DingusTestCase factory.

This changeset exposes the TestCase class so it can be customized in a straightforward fashion by third-party module. For example:

```
class PyTestCase(dingus.TestCase):
    def setup_method(self, method):
        self.setup()

    def teardown_method(self, method):
        self.teardown()

class SomeTestCase(dingus.DingusTestCase(my_module.my_obj, base=PyTestCase)):
    "test my_obj"
```

This changeset also has the effect of making object_under_test, names_under_test, and excludes available as class attributes on the generated DingusTestCase.

This changeset also makes a couple of simple improvements:
- Use list comprehension instead of generator for calculating names_under_test, and
- Use type() to explicitly generate the class rather than using a closure

I believe this change should be fully backward-compatible, and all tests still pass.
