### PR TITLE
Patch should set __wrapped__ to work with pytest fixtures

### DIFF
--- a/dingus.py
+++ b/dingus.py
@@ -75,6 +75,7 @@ class _Patcher:
                 return fn(*args, **kwargs)
             finally:
                 self.restore_object()
+        new_fn.__wrapped__ = fn
         return new_fn
 
     def __enter__(self):

--- a/tests/test_isolation.py
+++ b/tests/test_isolation.py
@@ -31,6 +31,13 @@ class WhenPatchingObjects:
         with patch('urllib2.urlopen'):
             assert str(urllib2.urlopen) == '<Dingus urllib2.urlopen>'
 
+    def should_set_wrapped_on_patched_function(self):
+        def urllib2():
+            pass
+        patch_urllib2 = patch('urllib2.urlopen')(urllib2)
+        assert patch_urllib2.__wrapped__ == urllib2
+
+
 class WhenIsolating:
     def should_isolate(self):
         @isolate("os.popen")


### PR DESCRIPTION
Pytest has magic for injecting fixtures:

``` python
import pytest
from dingus import patch
import urllib2

@pytest.fixture
def myfixture():
    return "some fixture"

def test_a_thing(myfixture):
    assert "fixture" in myfixture
# This passes.
```

This breaks when we start to use decorators (specifically dingus.patch):

``` python
@patch('urllib2.urlopen')
def test_decorator(myfixture):
    assert "fixture" in myfixture
# This is an error, pytest doesn't realise it should inject anything so calls 
# test_decorator with no arguments
```

Unless we set the magic __wrapped__ variable on the decorating function:

``` python
def test_wrapped_decorator(myfixture):
    assert "fixture" in myfixture
old_func = test_wrapped_decorator
test_wrapped_decorator = patch('urllib2.urlopen')(test_wrapped_decorator)
test_wrapped_decorator.__wrapped__ = old_func
# This passes.
```

I know I could use patch as a context manger but I want to patch multiple things which gets kinda ugly with context mangers.

__wrapped__ seems to be (sort of) a real thing, it's used in other places than just pytest and in >3.x it's set for you by functools.wraps so I think it's legitimate to add it.

Hope that's okay! :)
